### PR TITLE
feat: add unref() call to interval in SimpleActionServer - PERCEPTION-2312

### DIFF
--- a/src/actionlib/SimpleActionServer.js
+++ b/src/actionlib/SimpleActionServer.js
@@ -143,6 +143,7 @@ function SimpleActionServer(options) {
         that.statusMessage.header.stamp.nsecs = nsecs;
         statusPublisher.publish(that.statusMessage);
     }, 500); // publish every 500ms
+    statusInterval.unref(); // ensure the statusInterval doesn't prevent node from closing
 
 }
 


### PR DESCRIPTION
Making an assumption that an ActionServer would not be created in the browser (unref() is not available in the browser - only in node).