### PR TITLE
feat: Websocket server support (PERF-1285)

### DIFF
--- a/src/node/RosTCP.js
+++ b/src/node/RosTCP.js
@@ -25,7 +25,11 @@ function RosTCP(options) {
       port: options.port
     });
   }
-  if(options.http || options.socketio){
+
+  if(!this.socket && options.socket){
+    options.socket.binaryType = 'arraybuffer';
+    this.socket = Object.assign(options.socket, socketAdapter(this));
+  } else if(options.http || options.socketio){
     this.io = new SocketIO(options, this);
   }
 }

--- a/src/node/RosTCP.js
+++ b/src/node/RosTCP.js
@@ -69,6 +69,8 @@ RosTCP.prototype.connect = function(url) {
 RosTCP.prototype.attachSocket = function(socket) {
   socket.binaryType = 'arraybuffer';
   this.socket = Object.assign(socket, socketAdapter(this));
+
+  socket.emit('open');
 };
 
 module.exports = RosTCP;

--- a/src/node/RosTCP.js
+++ b/src/node/RosTCP.js
@@ -26,9 +26,7 @@ function RosTCP(options) {
     });
   }
 
-  if(!this.socket && options.socket){
-    
-  } else if(options.http || options.socketio){
+  if(options.http || options.socketio){
     this.io = new SocketIO(options, this);
   }
 }

--- a/src/node/RosTCP.js
+++ b/src/node/RosTCP.js
@@ -27,8 +27,7 @@ function RosTCP(options) {
   }
 
   if(!this.socket && options.socket){
-    options.socket.binaryType = 'arraybuffer';
-    this.socket = Object.assign(options.socket, socketAdapter(this));
+    
   } else if(options.http || options.socketio){
     this.io = new SocketIO(options, this);
   }
@@ -60,6 +59,17 @@ RosTCP.prototype.connect = function(url) {
     // Similarly for close
     this.socket.close = this.socket.end;
   }
+};
+
+/**
+ * Connects to a live socket
+ *
+ * * url (String|Int|Object): Address and port to connect to (see http://nodejs.org/api/net.html)
+ *     format {host: String, port: Int} or (port:Int), or "host:port"
+ */
+RosTCP.prototype.attachSocket = function(socket) {
+  socket.binaryType = 'arraybuffer';
+  this.socket = Object.assign(socket, socketAdapter(this));
 };
 
 module.exports = RosTCP;

--- a/src/node/RosTCP.js
+++ b/src/node/RosTCP.js
@@ -62,10 +62,9 @@ RosTCP.prototype.connect = function(url) {
 };
 
 /**
- * Connects to a live socket
+ * Connects to an existing socket
  *
- * * url (String|Int|Object): Address and port to connect to (see http://nodejs.org/api/net.html)
- *     format {host: String, port: Int} or (port:Int), or "host:port"
+ * * socket (Object): Websocket
  */
 RosTCP.prototype.attachSocket = function(socket) {
   socket.binaryType = 'arraybuffer';


### PR DESCRIPTION
Add the ability to attach to an existing WebSocket from a websocket server vs a connection URL.

URL format `<scheme>://<host>:<port>` (e.g. ws://localhost:80)